### PR TITLE
Add support for automatically crafting a pallet of pallets.

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -184,6 +184,13 @@ local function create_load_pallet_recipe(item)
     allow_decomposition = allow_palleting_decomposition
   }
 
+  -- special case for pallet of pallets
+  if item.name == empty_pallet_item.name then
+    recipe.ingredients = {
+      {type = "item", name = item.name, amount = get_items_per_pallet(item) + 1}
+    }
+  end
+
   data:extend({recipe})
   return recipe
 end
@@ -213,6 +220,13 @@ local function create_unload_pallet_recipe(item)
     hide_from_stats = hide_palleting_from_production_stats,
     allow_decomposition = allow_palleting_decomposition
   }
+
+  -- special case for pallet of pallets
+  if item.name == empty_pallet_item.name then
+    recipe.results = {
+      {type = "item", name = item.name, amount = get_items_per_pallet(item) + 1}
+    }
+  end
 
   data:extend({recipe})
   return recipe


### PR DESCRIPTION
Add support for a pallet of pallets, as inserters and loaders refuse to load the separate 'pallet' ingredient when there is already a 'pallet' ingredient, preventing a stack of pallets from being automatically crafted.

Resolves #1 